### PR TITLE
Fixes access rights in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,10 @@ WORKDIR /app
 
 RUN groupadd --system --gid 1001 faaast \
     && useradd --system --uid 1001 --gid 1001 --no-create-home faaast \
-    # restrict permissions on working directory /app
     && chgrp -R 0 /app \
     && chmod -R g=u /app \
-    # Create directories to which FA³ST needs permissions
-    && mkdir /app/resources /app/logs /app/PKI /app/USERS_PKI \
-    # Grant read and write permissions on created directories
-    && chmod -R ugo+rw /app/resources /app/PKI /app/USERS_PKI /app/logs
+    && chown -R faaast:faaast /app \
+    && mkdir /app/resources /app/logs /app/PKI /app/USERS_PKI
 
 USER faaast
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN groupadd --system --gid 1001 faaast \
     && useradd --system --uid 1001 --gid 1001 --no-create-home faaast \
     && chgrp -R 0 /app \
     && chmod -R g=u /app \
-    && chown -R faaast:faaast /app \
-    && mkdir /app/resources /app/logs /app/PKI /app/USERS_PKI
+    && mkdir /app/resources /app/logs /app/PKI /app/USERS_PKI \
+    && chown -R faaast:faaast /app
 
 USER faaast
 


### PR DESCRIPTION
This issued caused a crash when using OPC UA asset connection with a `FileNotFoundException (Permission denied)`.